### PR TITLE
Add support for browsers that have implemented document.currentScript. 

### DIFF
--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -14,7 +14,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var WEB_WORKERS = {};
     var HAS_SHARED_WORKER = typeof SharedWorker !== 'undefined';
     var HAS_WEB_WORKER = typeof Worker !== 'undefined';
-    var BASE_URI = document._currentScript.ownerDocument.baseURI;
+    var BASE_URI = (document.currentScript || document._currentScript)
+        .ownerDocument.baseURI;
     var WORKER_SCOPE_URL =
         Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
 


### PR DESCRIPTION
The _currentScript version is added by the webcomponents.js polyfill if needed, which it isn't in Chrome and Safari. https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript http://webcomponents.org/polyfills/html-imports/

Fixes #43   

This restores the functionality removed in https://github.com/PolymerElements/app-storage/commit/cd26416060df7d801b7af10ceb86a41b96875dd8.