### PR TITLE
Addresses incorrect access of current script.

### DIFF
--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -14,7 +14,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var WEB_WORKERS = {};
     var HAS_SHARED_WORKER = typeof SharedWorker !== 'undefined';
     var HAS_WEB_WORKER = typeof Worker !== 'undefined';
-    var BASE_URI = document._currentScript.ownerDocument.baseURI;
+    // NOTE(cdata): see http://www.2ality.com/2014/05/current-script.html
+    var currentScript = document._currentScript || document.currentScript ||
+        (function() {
+          var scripts = document.getElementsByTagName('script');
+          return scripts[scripts.length - 1];
+        })();
+    var BASE_URI = currentScript.ownerDocument.baseURI;
     var WORKER_SCOPE_URL =
         Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
 


### PR DESCRIPTION
The previous implementation had a hard dependency on the Web Components
polyfill, which creates a `document._currentScript` property. The new
implementation uses `document._currentScript` if it is set, but also
uses two fallbacks if it is not.

Fixes #43 