### PR TITLE
fix #75 - refresh bindings by setting empty object first

### DIFF
--- a/app-localstorage/app-localstorage-document.html
+++ b/app-localstorage/app-localstorage-document.html
@@ -199,7 +199,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         this.syncToMemory(function() {
-          this.set('data', this.__parseValueFromStorage());
+          var data = this.__parseValueFromStorage();
+          if (typeof(data)=='object') {
+            this.data = {};
+          }
+          this.set('data', data);
         });
       },
 
@@ -210,6 +214,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return;
         }
         this.syncToMemory(function() {
+          if (typeof(event.detail.data)=='object') {
+            this.data = {};
+          }
           this.set('data', event.detail.data);
         });
       },


### PR DESCRIPTION
Here's a JSBin demonstrating the fix: http://jsbin.com/fuhozanomo

Writing in the input updates both text labels, whereas before one of them was breaking.

This was inspired by the section on [dirty checking in the polymer devguide](https://www.polymer-project.org/1.0/docs/devguide/model-data#override-dirty-check).