### PR TITLE
Correct typo within app-storage-behavior.html associated with the description of valueIsEmpty();

### DIFF
--- a/app-storage-behavior.html
+++ b/app-storage-behavior.html
@@ -268,7 +268,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * A convenience method. Returns true iff value is null, undefined,
+       * A convenience method. Returns true if value is null, undefined,
        * an empty array, or an object with no keys.
        */
       valueIsEmpty: function(value) {


### PR DESCRIPTION
Fixes a typo within the description of valueIsEmpty() associated with `Polymer.AppStorageBehavior`.