### PR TITLE
Fixes #44 - check  if data is defined  when selecting persistedData state

### DIFF
--- a/app-indexeddb-mirror/app-indexeddb-mirror.html
+++ b/app-indexeddb-mirror/app-indexeddb-mirror.html
@@ -25,10 +25,14 @@ property. As live data changes, `app-indexeddb-mirror` caches a copy of the live
 data in a local IndexedDB database. When the app is no longer connected to the
 network, `app-indexeddb-mirror` toggles its `persistedData` property to refer
 to a read-only copy of the corresponding data in IndexedDB.
+When the app start, until the `data` property is initialized, the element serves
+the cached read-only data to `persistedData` property if data was previously
+cached.
 
 This element is particularly useful in cases where an API or storage layer (such
 as Firebase, for example) does not support caching data for later use during
 user sessions that begin while the user is disconnected from the network.
+It also enables quick loading of the initial state of the app.
 
 Here is an example of using `app-indexeddb-mirror` with `iron-ajax`:
 
@@ -249,7 +253,8 @@ be available through this element.
             return this.client.validateSession(this.session);
           });
 
-          if (this.online) {
+          // persisted Data is linked to data if online && data is defined
+          if (this.online && this.data !== undefined) {
             this.persistedData = this.data;
             this.linkPaths('data', 'persistedData');
           } else {
@@ -257,7 +262,7 @@ be available through this element.
             this._enqueueTransaction(function() {
               return this.getStoredValue().then(function(value) {
                 // We may have gone online since retrieving the persisted value..
-                if (this.online || !this.client.supportsMirroring) {
+                if (this.online && this.data !== undefined || !this.client.supportsMirroring) {
                   return;
                 }
                 this.persistedData = value;

--- a/test/app-indexeddb-mirror/app-indexeddb-mirror.html
+++ b/test/app-indexeddb-mirror/app-indexeddb-mirror.html
@@ -74,7 +74,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('basic mirroring', function() {
-        var mirror;
+        var mirror,
+            mirrorForCheck;
 
         setup(function() {
           mirror = fixture('BasicMirror');
@@ -117,6 +118,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             return mirror.transactionsComplete.then(function() {
               return expectPersistedValue(mirror.key, mirror.data);
+            });
+          });
+
+          test('boots up with persisted value when data is undefined', function() {
+            if (!mirror.client.supportsMirroring) {
+              return;
+            }
+            
+            var testData = {
+	            foo: 'bar'
+            };
+            
+            // Initialize Storage with test data 
+            mirror.data = testData;
+            expect(mirror.persistedData).to.be.deep.equal(mirror.data);
+            
+            // destroy mirror
+            mirror.client.closeDb();
+            
+            // boot test mirror
+            mirrorForCheck = fixture('SecondMirror');
+            
+            // Check the non-existence of data
+            expect(mirrorForCheck.data).to.be.deep.equal(undefined);
+            
+            return mirror.transactionsComplete.then(function() {
+              // check value in Storage
+              return expectPersistedValue(mirrorForCheck.key, testData)
+                  .then(function () {
+	
+	                  // Check: correct initial value of persistedData && data is still undefined
+	                  expect(mirrorForCheck.data).to.be.deep.equal(undefined);
+	                  expect(mirrorForCheck.persistedData).to.be.deep.equal(testData);
+                  });
             });
           });
         });


### PR DESCRIPTION
Fixes #44 

Allow for initial cached data to be accessible until data itself is defined.

When the app start, until the `data` property is initialized, the element serves
the cached read-only data to `persistedData` property if data was previously
cached.
It enables quick loading of the initial app state and stay coherent with the 
element behavior.
