### PR TITLE
add object.assign polyfill and skip tests ctx

### DIFF
--- a/test/app-storage-compatibility-suite.html
+++ b/test/app-storage-compatibility-suite.html
@@ -7,9 +7,35 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
 <script>
 (function() {
   'use strict';
+
+  if (typeof Object.assign != 'function') {
+    Object.assign = function(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    };
+  }
 
   function testAppStorageDocumentCompatibility(extendedContext) {
     var context = {
@@ -23,7 +49,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       unsetValue: function(storage) {
         storage.set('data', null);
         return storage.transactionsComplete;
-      }
+      },
+      skipTests: false
     };
 
     function awaitStoredValue(storage, path) {
@@ -36,6 +63,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Object.assign(context, extendedContext);
 
     suite('app storage compatibility: <' + context.tagName + '>', function() {
+      setup(function() {
+        if (context.skipTests) {
+          this.skip();
+        }
+      });
+
       suite('basic storage scenarios', function() {
         var storage;
 

--- a/test/app-storage-compatibility-suite.html
+++ b/test/app-storage-compatibility-suite.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
   'use strict';
 
+  // sourced from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
   if (typeof Object.assign != 'function') {
     Object.assign = function(target, varArgs) { // .length of function is 2
       'use strict';

--- a/test/app-storage-compatibility-suite.html
+++ b/test/app-storage-compatibility-suite.html
@@ -11,33 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 (function() {
   'use strict';
-
-  // sourced from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
-  if (typeof Object.assign != 'function') {
-    Object.assign = function(target, varArgs) { // .length of function is 2
-      'use strict';
-      if (target == null) { // TypeError if undefined or null
-        throw new TypeError('Cannot convert undefined or null to object');
-      }
-
-      var to = Object(target);
-
-      for (var index = 1; index < arguments.length; index++) {
-        var nextSource = arguments[index];
-
-        if (nextSource != null) { // Skip over if undefined or null
-          for (var nextKey in nextSource) {
-            // Avoid bugs when hasOwnProperty is shadowed
-            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-              to[nextKey] = nextSource[nextKey];
-            }
-          }
-        }
-      }
-      return to;
-    };
-  }
-
   function testAppStorageDocumentCompatibility(extendedContext) {
     var context = {
       tagName: 'unknown-element',
@@ -61,7 +34,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     }
 
-    Object.assign(context, extendedContext);
+    if (extendedContext) {
+      for (var key in extendedContext) {
+        context[key] = extendedContext[key];
+      }
+    }
 
     suite('app storage compatibility: <' + context.tagName + '>', function() {
       setup(function() {


### PR DESCRIPTION
Tests will not run at all on IE even if you want to skip the tests without the Polyfill. Additionally, I added functionality to skip tests. Useful when your storage uses features not available in browsers that `app-storage` supports.