### PR TITLE
Fix type-checking and property renaming for Closure Compiler.

### DIFF
--- a/app-indexeddb-mirror/app-indexeddb-mirror-client.html
+++ b/app-indexeddb-mirror/app-indexeddb-mirror-client.html
@@ -93,13 +93,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var port = worker.port;
 
             port.addEventListener('message', function onMessage(event) {
-              if (event.data && event.data.id === id) {
+              if (event.data && event.data['id'] === id) {
                 port.removeEventListener('message', onMessage);
-                resolve(event.data.result);
+                resolve(event.data['result']);
               }
             });
 
-            message.id = id;
+            message['id'] = id;
 
             port.postMessage(message);
           }.bind(this));
@@ -155,10 +155,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           worker.port.addEventListener('message', function(event) {
             if (event.data &&
-                event.data.type === 'app-mirror-connected') {
+                event.data['type'] === 'app-mirror-connected') {
               console.log('App IndexedDB Client connected!');
               this[CONNECTED] = true;
-              this[SUPPORTS_MIRRORING] = event.data.supportsIndexedDB;
+              this[SUPPORTS_MIRRORING] = event.data['supportsIndexedDB'];
               resolve(worker);
             }
           }.bind(this));
@@ -169,7 +169,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           worker.port.start();
           worker.port.postMessage({
-            type: 'app-mirror-connect'
+            'type': 'app-mirror-connect'
           });
         }.bind(this));
       }

--- a/app-indexeddb-mirror/app-indexeddb-mirror-worker.js
+++ b/app-indexeddb-mirror/app-indexeddb-mirror-worker.js
@@ -249,8 +249,8 @@
 
       port.start();
       port.postMessage({
-        type: 'app-mirror-connected',
-        supportsIndexedDB: this.supportsIndexedDB
+        'type': 'app-mirror-connected',
+        'supportsIndexedDB': this.supportsIndexedDB
       });
 
       console.log('New client connected.');
@@ -270,31 +270,27 @@
         return null;
       }
 
-      var id = event.data.id;
+      var id = event.data['id'];
 
-      switch(event.data.type) {
+      switch (event.data['type']) {
         case 'app-mirror-close-db':
           this.closeDb().then(function() {
-            port.postMessage({
-              type: 'app-mirror-db-closed',
-              id: id
-            });
+            port.postMessage({'type': 'app-mirror-db-closed', 'id': id});
           });
         case 'app-mirror-validate-session':
-          this.validateSession(event.data.session).then(function() {
-            port.postMessage({
-              type: 'app-mirror-session-validated',
-              id: id
-            });
+          this.validateSession(event.data['session']).then(function() {
+            port.postMessage(
+                {'type': 'app-mirror-session-validated', 'id': id});
           });
           break;
         case 'app-mirror-transaction':
-          this.transaction(event.data.method, event.data.key, event.data.value)
+          this.transaction(
+                  event.data['method'], event.data['key'], event.data['value'])
               .then(function(result) {
                 port.postMessage({
-                  type: 'app-mirror-transaction-result',
-                  id: id,
-                  result: result
+                  'type': 'app-mirror-transaction-result',
+                  'id': id,
+                  'result': result
                 });
               });
           break;

--- a/app-indexeddb-mirror/common-worker-scope.js
+++ b/app-indexeddb-mirror/common-worker-scope.js
@@ -36,7 +36,7 @@
   self.addEventListener('message', function(event) {
     var data = event.data;
 
-    if (data && data.type === 'common-worker-connect') {
+    if (data && data['type'] === 'common-worker-connect') {
       var EventConstructor =
           self.CustomEvent ||
           self.Event ||

--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (this.webWorker) {
         this.webWorker.postMessage({
-          type: 'common-worker-connect'
+          'type': 'common-worker-connect'
         }, [this.channel.port2]);
       }
     }


### PR DESCRIPTION
Update `app-indexeddb-mirror` implementation to quote the property names
of all `MessageEvent.data` objects and all `postMessage` arguments.

This prevents errors likes the following in Closure Compiler with
type-checking enabled:
```
ERROR - Property session never defined on MessageEvent.prototype.data
          this.validateSession(event.data.session).then(function() {
                                          ^^^^^^^
```

This also prevents Closure Compiler renaming those properties with
advanced optimizations, ensuring access by both client and worker.