### PR TITLE
fix issue where baseURI was undef in modules

### DIFF
--- a/app-indexeddb-mirror/app-indexeddb-mirror-client.html
+++ b/app-indexeddb-mirror/app-indexeddb-mirror-client.html
@@ -27,18 +27,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @param {string} _workerUrl The URL to use when initializing the
      * corresponding WebWorker.
+     * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
      *
      * @constructor
      */
     Polymer.AppIndexedDBMirrorClient =
-        function AppIndexedDBMirrorClient(_workerUrl) {
+        function AppIndexedDBMirrorClient(_workerUrl, baseUri) {
       this[WORKER_URL] = _workerUrl;
       this[CONNECTED] = false;
       this[MESSAGE_ID] = 0;
       this[CONNECTS_TO_WORKER] = null;
       this[SUPPORTS_MIRRORING] = null;
 
-      this.connect();
+      this.connect(baseUri);
     };
 
     Polymer.AppIndexedDBMirrorClient.prototype = {
@@ -139,11 +140,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Instantiates (if necessary) and connects to the backing worker
        * instance.
        *
+       * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
        * @return {Promise} A promise that resolves when the worker has been
        * created and a handshake has been returned. The worker is an instance
        * of `SharedWorker` (if available), or else `Polymer.CommonWorker`.
        */
-      connect: function() {
+      connect: function(baseUri) {
         if (this[CONNECTED] || this[CONNECTS_TO_WORKER]) {
           return this[CONNECTS_TO_WORKER];
         }
@@ -151,7 +153,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         console.log('App IndexedDB Client connecting..');
 
         return this[CONNECTS_TO_WORKER] = new Promise(function(resolve) {
-          var worker = new Polymer.CommonWorker(this[WORKER_URL]);
+          debugger;
+          var worker = new Polymer.CommonWorker(this[WORKER_URL], baseUri);
 
           worker.port.addEventListener('message', function(event) {
             if (event.data &&

--- a/app-indexeddb-mirror/app-indexeddb-mirror-client.html
+++ b/app-indexeddb-mirror/app-indexeddb-mirror-client.html
@@ -153,7 +153,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         console.log('App IndexedDB Client connecting..');
 
         return this[CONNECTS_TO_WORKER] = new Promise(function(resolve) {
-          debugger;
           var worker = new Polymer.CommonWorker(this[WORKER_URL], baseUri);
 
           worker.port.addEventListener('message', function(event) {

--- a/app-indexeddb-mirror/app-indexeddb-mirror.html
+++ b/app-indexeddb-mirror/app-indexeddb-mirror.html
@@ -129,6 +129,15 @@ be available through this element.
     (function() {
       'use strict';
 
+      // NOTE(cdata): see http://www.2ality.com/2014/05/current-script.html
+      var __currentScript = document._currentScript || document.currentScript ||
+          (function() {
+            var scripts = document.getElementsByTagName('script');
+            return scripts[scripts.length - 1];
+          })();
+
+      var IS_JS_MODULE = __currentScript.getAttribute('type') === 'module';
+
       Polymer({
         is: 'app-indexeddb-mirror',
 
@@ -235,6 +244,10 @@ be available through this element.
         },
 
         __computeClient: function(workerUrl) {
+          if (IS_JS_MODULE) {
+            return new Polymer.AppIndexedDBMirrorClient(workerUrl, this.importPath);
+          }
+
           return new Polymer.AppIndexedDBMirrorClient(workerUrl);
         },
 

--- a/app-indexeddb-mirror/app-indexeddb-mirror.html
+++ b/app-indexeddb-mirror/app-indexeddb-mirror.html
@@ -129,15 +129,6 @@ be available through this element.
     (function() {
       'use strict';
 
-      // NOTE(cdata): see http://www.2ality.com/2014/05/current-script.html
-      var __currentScript = document._currentScript || document.currentScript ||
-          (function() {
-            var scripts = document.getElementsByTagName('script');
-            return scripts[scripts.length - 1];
-          })();
-
-      var IS_JS_MODULE = __currentScript.getAttribute('type') === 'module';
-
       Polymer({
         is: 'app-indexeddb-mirror',
 
@@ -244,7 +235,7 @@ be available through this element.
         },
 
         __computeClient: function(workerUrl) {
-          if (IS_JS_MODULE) {
+          if (this.importPath) {
             return new Polymer.AppIndexedDBMirrorClient(workerUrl, this.importPath);
           }
 

--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var WEB_WORKERS = {};
     var HAS_SHARED_WORKER = typeof SharedWorker !== 'undefined';
     var HAS_WEB_WORKER = typeof Worker !== 'undefined';
-    // NOTE(cdata): see http://www.2ality.com/2014/05/current-script.html
     // Use case only for Polymer 1
     var currentScript = document._currentScript || document.currentScript;
     var baseUriCurrentScript;

--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -15,30 +15,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var HAS_SHARED_WORKER = typeof SharedWorker !== 'undefined';
     var HAS_WEB_WORKER = typeof Worker !== 'undefined';
     // NOTE(cdata): see http://www.2ality.com/2014/05/current-script.html
-    var currentScript = document._currentScript || document.currentScript ||
-        (function() {
-          var scripts = document.getElementsByTagName('script');
-          return scripts[scripts.length - 1];
-        })();
-    var IS_JS_MODULE = currentScript.getAttribute('type') === 'module';
-    var workerScopeUrl;
+    // Use case only for Polymer 1
+    var currentScript = document._currentScript || document.currentScript;
 
-    if (!IS_JS_MODULE) {
-      var BASE_URI = (function() {
-        // Polymer 2 baseURI polyfill for IE and Safari
-        if (Polymer.Element && window.HTMLImports && HTMLImports.importForElement) {
-          return HTMLImports.importForElement(
-              /** @type {!HTMLScriptElement} */(document.currentScript)).baseURI;
-        }
-        // Polymer 1 or no HTML Imports
-        currentScript = document._currentScript ? document._currentScript :
-            document.currentScript;
-        return currentScript.ownerDocument.baseURI;
-      })();
+    var BASE_URI = (function() {
+      // Polymer 1 and no HTML Imports
+      currentScript = document._currentScript ? document._currentScript :
+          document.currentScript;
+      return currentScript.ownerDocument.baseURI;
+    })();
 
-      workerScopeUrl =
-          Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
-    }
+    var WORKER_SCOPE_CURRENT_SCRIPT =
+        Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
 
     /**
      * A proxy class for creating `SharedWorker` if available. If not available,
@@ -56,21 +44,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @param {string} workerUrl The URL of the worker script to create a worker
      * instance with.
-     * @param {string} baseUri The base uri of app-storage/app-indexeddb-mirror
+     * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
      *
      * @constructor
      */
-    Polymer.CommonWorker = function CommonWorker (workerUrl, baseUri) {
-      if (!workerScopeUrl) {
-        workerScopeUrl =
-          Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', baseUri);
-      }
-
+    Polymer.CommonWorker = function CommonWorker(workerUrl, baseUri) {
       if (HAS_SHARED_WORKER) {
         return new SharedWorker(workerUrl);
 
       } else if (HAS_WEB_WORKER) {
         if (!WEB_WORKERS.hasOwnProperty(workerUrl)) {
+          if (!workerScopeUrl) {
+            if (typeof baseUri !== 'string') {
+              baseUri = WORKER_SCOPE_CURRENT_SCRIPT;
+            }
+
+            workerScopeUrl =
+              Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', baseUri);
+          }
+
           WEB_WORKERS[workerUrl] =
               new Worker(workerScopeUrl + '?' + workerUrl);
         }

--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -20,21 +20,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var scripts = document.getElementsByTagName('script');
           return scripts[scripts.length - 1];
         })();
+    var IS_JS_MODULE = currentScript.getAttribute('type') === 'module';
+    var workerScopeUrl;
 
-    var BASE_URI = (function() {
-      // Polymer 2 baseURI polyfill for IE and Safari
-      if (Polymer.Element && window.HTMLImports && HTMLImports.importForElement) {
-        return HTMLImports.importForElement(
-            /** @type {!HTMLScriptElement} */(document.currentScript)).baseURI;
-      }
-      // Polymer 1 or no HTML Imports
-      currentScript = document._currentScript ? document._currentScript :
-          document.currentScript;
-      return currentScript.ownerDocument.baseURI;
-    })();
+    if (!IS_JS_MODULE) {
+      var BASE_URI = (function() {
+        // Polymer 2 baseURI polyfill for IE and Safari
+        if (Polymer.Element && window.HTMLImports && HTMLImports.importForElement) {
+          return HTMLImports.importForElement(
+              /** @type {!HTMLScriptElement} */(document.currentScript)).baseURI;
+        }
+        // Polymer 1 or no HTML Imports
+        currentScript = document._currentScript ? document._currentScript :
+            document.currentScript;
+        return currentScript.ownerDocument.baseURI;
+      })();
 
-    var WORKER_SCOPE_URL =
-        Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
+      workerScopeUrl =
+          Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
+    }
 
     /**
      * A proxy class for creating `SharedWorker` if available. If not available,
@@ -52,17 +56,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @param {string} workerUrl The URL of the worker script to create a worker
      * instance with.
+     * @param {string} baseUri The base uri of app-storage/app-indexeddb-mirror
      *
      * @constructor
      */
-    Polymer.CommonWorker = function CommonWorker (workerUrl) {
+    Polymer.CommonWorker = function CommonWorker (workerUrl, baseUri) {
+      if (!workerScopeUrl) {
+        workerScopeUrl =
+          Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', baseUri);
+      }
+
       if (HAS_SHARED_WORKER) {
         return new SharedWorker(workerUrl);
 
       } else if (HAS_WEB_WORKER) {
         if (!WEB_WORKERS.hasOwnProperty(workerUrl)) {
           WEB_WORKERS[workerUrl] =
-              new Worker(WORKER_SCOPE_URL + '?' + workerUrl);
+              new Worker(workerScopeUrl + '?' + workerUrl);
         }
 
       } else {

--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -19,11 +19,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var baseUriCurrentScript;
     var workerScopeUrl;
 
+    // Polymer 1 and no HTML Imports
     if (currentScript) {
-      baseUriCurrentScript = (function() {
-        // Polymer 1 and no HTML Imports
-        return currentScript.ownerDocument.baseURI;
-      })();
+      baseUriCurrentScript = currentScript.ownerDocument.baseURI;
     }
 
     /**

--- a/app-indexeddb-mirror/common-worker.html
+++ b/app-indexeddb-mirror/common-worker.html
@@ -17,16 +17,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // NOTE(cdata): see http://www.2ality.com/2014/05/current-script.html
     // Use case only for Polymer 1
     var currentScript = document._currentScript || document.currentScript;
+    var baseUriCurrentScript;
+    var workerScopeUrl;
 
-    var BASE_URI = (function() {
-      // Polymer 1 and no HTML Imports
-      currentScript = document._currentScript ? document._currentScript :
-          document.currentScript;
-      return currentScript.ownerDocument.baseURI;
-    })();
-
-    var WORKER_SCOPE_CURRENT_SCRIPT =
-        Polymer.ResolveUrl.resolveUrl('common-worker-scope.js', BASE_URI);
+    if (currentScript) {
+      baseUriCurrentScript = (function() {
+        // Polymer 1 and no HTML Imports
+        return currentScript.ownerDocument.baseURI;
+      })();
+    }
 
     /**
      * A proxy class for creating `SharedWorker` if available. If not available,
@@ -56,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!WEB_WORKERS.hasOwnProperty(workerUrl)) {
           if (!workerScopeUrl) {
             if (typeof baseUri !== 'string') {
-              baseUri = WORKER_SCOPE_CURRENT_SCRIPT;
+              baseUri = baseUriCurrentScript;
             }
 
             workerScopeUrl =


### PR DESCRIPTION
**Description:** baseURI was failing in Polymer 3-modulized. This is because our `currentScript` polyfill was returning the `script[type="module]` that imported this module, and then calling `.baseURI` on that returned undefined. I was able to find a fix that passed `importPath` to these scripts which should return a path related to `import.meta.url`.

This `importPath` fix will run if it is defined and will fallback to `document.currentScript.baseURI` if not (which should only be in Polymer 1)

**For reviewing:** I would recommend following the data flow of `importPath` which is:

`app-indexeddb-mirror.html` -> `app-indexeddb-mirror-client.html` -> `common-worker.html`

I have tested this in polymer 3.0 with a manual fix of `importPath` and it passed our test suite with flying colors. ✈️🌈

**NOTE:** Currently `importPath` is broken in 3.0 see Polymer/polymer-modulizer#361 and Polymer/polymer-modulizer#363