### PR TITLE
Convert CommonWorker and AppIndexedDBMirrorClient to ES6 classes.

### DIFF
--- a/app-indexeddb-mirror/app-indexeddb-mirror-client.js
+++ b/app-indexeddb-mirror/app-indexeddb-mirror-client.js
@@ -21,29 +21,26 @@ var worker = null;
  * Class that implements a client for initializing and negotiating
  * transactions with a worker containing an instance of
  * `AppIndexedDBMirrorWorker`.
- *
- * @param {string} _workerUrl The URL to use when initializing the
- * corresponding WebWorker.
- * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
- *
- * @constructor
  */
-export const AppIndexedDBMirrorClient = function AppIndexedDBMirrorClient(
-    _workerUrl, baseUri) {
-  this[WORKER_URL] = _workerUrl;
-  this[CONNECTED] = false;
-  this[MESSAGE_ID] = 0;
-  this[CONNECTS_TO_WORKER] = null;
-  this[SUPPORTS_MIRRORING] = null;
+export class AppIndexedDBMirrorClient {
+  /**
+   * @param {string} _workerUrl The URL to use when initializing the
+   * corresponding WebWorker.
+   * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
+   */
+  constructor(_workerUrl, baseUri) {
+    this[WORKER_URL] = _workerUrl;
+    this[CONNECTED] = false;
+    this[MESSAGE_ID] = 0;
+    this[CONNECTS_TO_WORKER] = null;
+    this[SUPPORTS_MIRRORING] = null;
 
-  this.connect(baseUri);
-};
-
-AppIndexedDBMirrorClient.prototype = {
+    this.connect(baseUri);
+  }
 
   get supportsMirroring() {
     return this[SUPPORTS_MIRRORING];
-  },
+  }
 
   /**
    * Requests that the worker validate the current session against the
@@ -56,7 +53,7 @@ AppIndexedDBMirrorClient.prototype = {
    * @return {Promise|undefined} A promise that resolves when the worker confirms that
    * the session has been validated.
    */
-  validateSession: function(session) {
+  validateSession(session) {
     if (session === undefined) {
       // Ignore session `undefined` conventionally, as it means the session
       // (such as the user ID) has not been initialized yet.
@@ -64,7 +61,7 @@ AppIndexedDBMirrorClient.prototype = {
     }
 
     return this.post({type: 'app-mirror-validate-session', session: session});
-  },
+  }
 
   /**
    * Sends a message to the worker and awaits and handles a corresponding
@@ -77,7 +74,7 @@ AppIndexedDBMirrorClient.prototype = {
    * unique ID, so the first worker response that echos this ID will be
    * used to resolve the promise.
    */
-  post: function(message) {
+  post(message) {
     return this.connect().then(function(worker) {
       if (!this[SUPPORTS_MIRRORING]) {
         return Promise.resolve({});
@@ -99,7 +96,7 @@ AppIndexedDBMirrorClient.prototype = {
         port.postMessage(message);
       }.bind(this));
     }.bind(this));
-  },
+  }
 
   /**
    * Requests that the worker perform a transaction (supported verbs are
@@ -115,18 +112,18 @@ AppIndexedDBMirrorClient.prototype = {
    * @return {Promise} A promise that resolves when the worker indicates
    * that the transaction has completed.
    */
-  transaction: function(method, key, value) {
+  transaction(method, key, value) {
     return this.post({
       type: 'app-mirror-transaction',
       method: method,
       key: key,
       value: value
     });
-  },
+  }
 
-  closeDb: function() {
+  closeDb() {
     return this.post({type: 'app-mirror-close-db'});
-  },
+  }
 
   /**
    * Instantiates (if necessary) and connects to the backing worker
@@ -137,7 +134,7 @@ AppIndexedDBMirrorClient.prototype = {
    * created and a handshake has been returned. The worker is an instance
    * of `SharedWorker` (if available), or else `Polymer.CommonWorker`.
    */
-  connect: function(baseUri) {
+  connect(baseUri) {
     if (this[CONNECTED] || this[CONNECTS_TO_WORKER]) {
       return this[CONNECTS_TO_WORKER];
     }

--- a/app-indexeddb-mirror/app-indexeddb-mirror-client.js
+++ b/app-indexeddb-mirror/app-indexeddb-mirror-client.js
@@ -162,4 +162,4 @@ export class AppIndexedDBMirrorClient {
              worker.port.postMessage({'type': 'app-mirror-connect'});
            }.bind(this));
   }
-}
+};

--- a/app-indexeddb-mirror/common-worker.js
+++ b/app-indexeddb-mirror/common-worker.js
@@ -112,4 +112,4 @@ export class CommonWorker {
       }
     }
   }
-}
+};

--- a/app-indexeddb-mirror/common-worker.js
+++ b/app-indexeddb-mirror/common-worker.js
@@ -74,42 +74,42 @@ export class CommonWorker {
       this.webWorker.postMessage(
           {'type': 'common-worker-connect'}, [this.channel.port2]);
     }
+  }
 
-    /**
-     * @type {MessagePort} A port that is unique to each instance of
-     * CommonWorker. Messages posted to this port can be received inside of
-     * the worker instance.
-     */
-    get port() {
-      return this.channel.port1;
+  /**
+   * @type {MessagePort} A port that is unique to each instance of
+   * CommonWorker. Messages posted to this port can be received inside of
+   * the worker instance.
+   */
+  get port() {
+    return this.channel.port1;
+  }
+
+  /**
+   * A proxy method that forwards all calls to the backing `WebWorker`
+   * instance.
+   *
+   * @param {String|string|undefined} eventType The event to listen for
+   * @param {Function} listenerFunction The function to be attached to the event
+   * @param {Object=} options addEventListener Options object
+   */
+  addEventListener(eventType, listenerFunction, options) {
+    if (this.webWorker) {
+      return this.webWorker.addEventListener.apply(this.webWorker, arguments);
     }
+  }
 
-    /**
-     * A proxy method that forwards all calls to the backing `WebWorker`
-     * instance.
-     *
-     * @param {String|string|undefined} eventType The event to listen for
-     * @param {Function} listenerFunction The function to be attached to the event
-     * @param {Object=} options addEventListener Options object
-     */
-    addEventListener(eventType, listenerFunction, options) {
-      if (this.webWorker) {
-        return this.webWorker.addEventListener.apply(this.webWorker, arguments);
-      }
-    }
-
-    /**
-     * A proxy method that forwards all calls to the backing `WebWorker`
-     * instance.
-     *
-     * @param {...*} removeEventListenerArgs The arguments to call the same
-     * method on the `WebWorker` with.
-     */
-    removeEventListener(removeEventListenerArgs) {
-      if (this.webWorker) {
-        return this.webWorker.removeEventListener.apply(
-            this.webWorker, arguments);
-      }
+  /**
+   * A proxy method that forwards all calls to the backing `WebWorker`
+   * instance.
+   *
+   * @param {...*} removeEventListenerArgs The arguments to call the same
+   * method on the `WebWorker` with.
+   */
+  removeEventListener(removeEventListenerArgs) {
+    if (this.webWorker) {
+      return this.webWorker.removeEventListener.apply(
+          this.webWorker, arguments);
     }
   }
 };

--- a/app-indexeddb-mirror/common-worker.js
+++ b/app-indexeddb-mirror/common-worker.js
@@ -36,82 +36,80 @@ if (currentScript) {
  *
  * `WebWorker` instances can listen for a global `connect` event that is
  * semantically similar to the spec'd `connect` event in a `SharedWorker`.
- *
- * @param {string} workerUrl The URL of the worker script to create a worker
- * instance with.
- * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
- *
- * @constructor
  */
-export const CommonWorker = function CommonWorker(workerUrl, baseUri) {
-  if (HAS_SHARED_WORKER) {
-    return new SharedWorker(workerUrl);
+export class CommonWorker {
+  /**
+   * @param {string} workerUrl The URL of the worker script to create a worker
+   * instance with.
+   * @param {string=} baseUri The base uri of app-storage/app-indexeddb-mirror
+   */
+  constructor(workerUrl, baseUri) {
+    if (HAS_SHARED_WORKER) {
+      return new SharedWorker(workerUrl);
 
-  } else if (HAS_WEB_WORKER) {
-    if (!WEB_WORKERS.hasOwnProperty(workerUrl)) {
-      if (!workerScopeUrl) {
-        if (typeof baseUri !== 'string') {
-          baseUri = baseUriCurrentScript;
+    } else if (HAS_WEB_WORKER) {
+      if (!WEB_WORKERS.hasOwnProperty(workerUrl)) {
+        if (!workerScopeUrl) {
+          if (typeof baseUri !== 'string') {
+            baseUri = baseUriCurrentScript;
+          }
+
+          workerScopeUrl = resolveUrl('common-worker-scope.js', baseUri);
         }
 
-        workerScopeUrl = resolveUrl('common-worker-scope.js', baseUri);
+        WEB_WORKERS[workerUrl] = new Worker(workerScopeUrl + '?' + workerUrl);
       }
 
-      WEB_WORKERS[workerUrl] = new Worker(workerScopeUrl + '?' + workerUrl);
+    } else {
+      console.error(
+          'This browser does not support SharedWorker or' +
+          'WebWorker, but at least one of those two features is required for' +
+          'CommonWorker to do its thing.');
     }
 
-  } else {
-    console.error(
-        'This browser does not support SharedWorker or' +
-        'WebWorker, but at least one of those two features is required for' +
-        'CommonWorker to do its thing.');
-  }
+    this.channel = new MessageChannel();
+    this.webWorker = WEB_WORKERS[workerUrl];
 
-  this.channel = new MessageChannel();
-  this.webWorker = WEB_WORKERS[workerUrl];
-
-  if (this.webWorker) {
-    this.webWorker.postMessage(
-        {'type': 'common-worker-connect'}, [this.channel.port2]);
-  }
-};
-
-CommonWorker.prototype = {
-
-  /**
-   * @type {MessagePort} A port that is unique to each instance of
-   * CommonWorker. Messages posted to this port can be received inside of
-   * the worker instance.
-   */
-  get port() {
-    return this.channel.port1;
-  },
-
-  /**
-   * A proxy method that forwards all calls to the backing `WebWorker`
-   * instance.
-   *
-   * @param {String|string|undefined} eventType The event to listen for
-   * @param {Function} listenerFunction The function to be attached to the event
-   * @param {Object=} options addEventListener Options object
-   */
-  addEventListener: function(eventType, listenerFunction, options) {
     if (this.webWorker) {
-      return this.webWorker.addEventListener.apply(this.webWorker, arguments);
+      this.webWorker.postMessage(
+          {'type': 'common-worker-connect'}, [this.channel.port2]);
     }
-  },
 
-  /**
-   * A proxy method that forwards all calls to the backing `WebWorker`
-   * instance.
-   *
-   * @param {...*} removeEventListenerArgs The arguments to call the same
-   * method on the `WebWorker` with.
-   */
-  removeEventListener: function(removeEventListenerArgs) {
-    if (this.webWorker) {
-      return this.webWorker.removeEventListener.apply(
-          this.webWorker, arguments);
+    /**
+     * @type {MessagePort} A port that is unique to each instance of
+     * CommonWorker. Messages posted to this port can be received inside of
+     * the worker instance.
+     */
+    get port() {
+      return this.channel.port1;
+    }
+
+    /**
+     * A proxy method that forwards all calls to the backing `WebWorker`
+     * instance.
+     *
+     * @param {String|string|undefined} eventType The event to listen for
+     * @param {Function} listenerFunction The function to be attached to the event
+     * @param {Object=} options addEventListener Options object
+     */
+    addEventListener(eventType, listenerFunction, options) {
+      if (this.webWorker) {
+        return this.webWorker.addEventListener.apply(this.webWorker, arguments);
+      }
+    }
+
+    /**
+     * A proxy method that forwards all calls to the backing `WebWorker`
+     * instance.
+     *
+     * @param {...*} removeEventListenerArgs The arguments to call the same
+     * method on the `WebWorker` with.
+     */
+    removeEventListener(removeEventListenerArgs) {
+      if (this.webWorker) {
+        return this.webWorker.removeEventListener.apply(
+            this.webWorker, arguments);
+      }
     }
   }
-};
+}


### PR DESCRIPTION
This helps Analyzer understand them, for type generation.