### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/app-indexeddb-mirror/app-indexeddb-mirror.js
+++ b/app-indexeddb-mirror/app-indexeddb-mirror.js
@@ -134,6 +134,7 @@ import {AppIndexedDBMirrorClient} from './app-indexeddb-mirror-client.js';
 
 Polymer({
   is: 'app-indexeddb-mirror',
+  _template: null,
 
   behaviors: [AppStorageBehavior, AppNetworkStatusBehavior],
 

--- a/app-localstorage/app-localstorage-document.js
+++ b/app-localstorage/app-localstorage-document.js
@@ -40,6 +40,7 @@ import {AppStorageBehavior} from '../app-storage-behavior.js';
  */
 Polymer({
   is: 'app-localstorage-document',
+  _template: null,
 
   behaviors: [AppStorageBehavior],
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336